### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 allennlp==0.9.0
+beautifulsoup4==4.9.3
 boto==2.49.0
 boto3==1.9.238
 dask==2.1.0
@@ -12,6 +13,7 @@ librosa==0.7.0
 matplotlib==3.1.0
 networkx==2.3
 nltk>=3.4.5
+numba==0.48
 numpy==1.16.4
 pandas==0.24.2
 pytorch-nlp==0.4.1


### PR DESCRIPTION
Added two requirements for Punctuation Restoration.
Tested with Python 3.6.9 on Ubuntu 16.04 with the example script
The problem with numba is here described:
https://github.com/librosa/librosa/issues/1160